### PR TITLE
Add Football Edge, and fix four defects found running it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+cache/
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ compares those prices to the bookmaker's and flags where you have an edge.
 ## Setup
 
 ```bash
+./run.sh
+```
+
+That creates a virtualenv in `.venv` on first run, installs the dependencies
+and opens the app at http://localhost:8501. Needs Python 3.10 or newer; set
+`PYTHON=/path/to/python3.11` if `python3` is older. Arguments are passed
+through to Streamlit, so `./run.sh --server.port 8600` works.
+
+Or do it by hand:
+
+```bash
 pip install -r requirements.txt
 streamlit run app.py
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,233 @@
-# Rgm-site
-Rgm website
+# Football Edge
+
+Prices matches in the top five European leagues across four markets — match
+result, goals (over/under and both teams to score), corners, and cards — then
+compares those prices to the bookmaker's and flags where you have an edge.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+First run downloads about seven seasons per league from football-data.co.uk and
+caches them in `cache/`. That takes a minute or two; after that it is instant.
+The season window ends at whichever season is currently in progress, so the
+defaults do not go stale as the calendar moves on.
+
+Some divisions publish the current season's file only once a few matches have
+been played. A season that is not up yet is skipped with a note rather than
+failing the load.
+
+## How it works
+
+Everything rests on one idea used three times. Goals, corners and cards are all
+pairs of counts, so each gets the same model:
+
+```
+log(expected home count) = base + attack(home) + defence(away) + home advantage
+log(expected away count) = base + attack(away) + defence(home)
+```
+
+Fitted by maximum likelihood with exponential time decay, so recent matches
+carry more weight than old ones. Three details matter:
+
+- **Dixon-Coles correction** on goals. Plain Poisson under-predicts 0-0 and 1-1,
+  which means it systematically misprices the draw. The correction fixes it.
+- **Separate home and away parameters.** Home advantage is fitted, not assumed,
+  and it differs by league.
+- **Referee adjustment on cards.** A referee's card rate relative to what the
+  teams alone imply, shrunk toward neutral by how many matches you have seen him
+  do. This is the single biggest edge available in the cards market and most
+  people ignore it.
+
+From the fitted rates the code builds a joint distribution over scorelines and
+reads every market off it: 1X2, double chance, over/under any line, both teams
+to score, correct score, corner totals, most corners, card totals, and booking
+points at 10 per yellow and 25 per red.
+
+A bet is placed only when `probability × odds − 1` clears your minimum edge.
+Stakes are quarter-Kelly, capped at 2% of bankroll.
+
+## Files
+
+| File | What it does |
+|---|---|
+| `footy/data.py` | Downloads and caches results, corners, cards, referees, closing odds |
+| `footy/ratings.py` | The rating engine — Dixon-Coles and Poisson fitting |
+| `footy/markets.py` | Turns count distributions into market probabilities |
+| `footy/betting.py` | Margin removal, expected value, Kelly staking |
+| `footy/predict.py` | Fits all three models per league and prices a fixture |
+| `footy/backtest.py` | Walk-forward testing and calibration |
+| `app.py` | The dashboard |
+
+## Reading the dashboard
+
+On the fixtures tab, the filled bar is the model's probability and the vertical
+tick is the bookmaker's, with their margin removed. When the bar runs past the
+tick, you have a modelled edge. The bar turns green when that edge is positive.
+
+## What to expect
+
+Some things worth being clear about before you stake money:
+
+**Accuracy is the wrong target.** The bookmaker's closing odds are the most
+accurate football forecast that exists — they absorb team news, injuries,
+weather and the opinion of every sharp bettor who moved the line. You can be
+very accurate and still lose, because the price already contained your insight.
+What matters is whether your probability differs from theirs in the right
+direction more often than their margin costs you.
+
+**Check calibration before you check profit.** The backtest tab groups bets by
+predicted probability and shows what actually happened. If your 60% bucket wins
+48% of the time, no staking plan will rescue it. Fix calibration first.
+
+**Match result in these five leagues is the hardest market on earth.** It is the
+most liquid and most heavily modelled market in football. The blend slider
+exists because pure model output usually underperforms the market here.
+
+**Corners and cards are where the realistic edge lives.** Books price them with
+less care and move them more slowly. The referee factor in this model is a real
+informational advantage. The catch is that limits are low and prices move fast
+once anyone notices.
+
+**Sample size.** A 3% edge is invisible over 50 bets and only shows over several
+hundred. Any conclusion you draw from one month is noise. Expect long losing
+runs even when the model is genuinely good — the backtest reports maximum
+drawdown for exactly this reason.
+
+**The backtest flatters you.** It assumes you got the closing price on every
+selection, that limits were unlimited, and that no line moved against you. Real
+results are always worse than backtested ones.
+
+Set aside a fixed bankroll you are willing to lose entirely, and treat this as a
+research project that might pay for itself rather than as income.
+
+## The analysis workflow
+
+Your instinct — league card leaders, then last five or six matches split by
+venue, then the referee — is the right sequence. Three refinements make it hold
+up under money.
+
+**Adjust the league table for schedule.** A raw card table largely ranks teams by
+who they played and how often they were losing. `analysis.discipline_table`
+divides each team's actual cards by what the model expected for those exact
+fixtures. A ratio above 1.0 means genuinely more cards than the schedule
+implies. The `signal` column compares the gap to Poisson noise and marks most
+teams as noise, which is the honest answer.
+
+**Shrink the recent window.** Six matches of card counts is close to pure noise:
+at two cards a game the standard error on a six-match average is around 0.6
+cards, larger than the real difference between most teams. `recent_form` reports
+the raw average, the long-run average, and a shrunk figure that weights the
+recent number by how much of it you can believe. Bet the shrunk one.
+
+**Read the referee before the teams.** On cards markets the official is worth
+more than either side. `referee_table` reports cards per match, booking points,
+the home/away split, and fouls per card — the last being the better strictness
+measure, because it strips out the fact that some officials are handed busier
+fixtures. Appointments publish two or three days before kickoff and the market
+is often slow to reprice.
+
+Then apply the same shape to every other market:
+
+| Market | Raw number everyone quotes | What to use instead |
+|---|---|---|
+| Cards | Cards per game | Cards ÷ model expectation; fouls per card |
+| Corners | Corners won | Corner share, and shots per corner |
+| Goals | Goals scored | Shots on target, and conversion rate |
+| Result | Points per game | Shot-on-target difference |
+
+The pattern is the same each time. The count you are betting on is the lagging
+indicator; something that happens ten times more often is the leading one, and
+it stabilises over a far smaller sample.
+
+`context.py` adds the piece most models miss: corners and cards are consequences
+of match shape, not independent events. A one-sided fixture means the favourite
+camps in the opposition half — corners rise and tilt heavily to one side — while
+a less contested game produces fewer flashpoints and fewer bookings. Those
+coefficients are fitted from your data rather than assumed. Print them with
+`describe()` and check the signs match that story before trusting the
+adjustment.
+
+Use `brief.match_brief` for one fixture and `brief.slate_scan` to rank a whole
+matchday by expected cards, corners or goals.
+
+## Where to take it next
+
+1. **Add expected goals.** `soccerdata` pulls Understat and FBref. Fitting
+   ratings on xG instead of goals is the single largest accuracy upgrade
+   available, because goals are a noisy sample of chances created.
+2. **Add a live odds feed.** The Odds API gives corners and cards prices across
+   bookmakers, which this model currently cannot see.
+3. **Track closing line value.** Log the price you took and the price at kickoff.
+   If you consistently beat the closing line, you have a real edge, and you will
+   know it months before your profit and loss does.
+4. **Team news.** A missing first-choice striker is worth more than any
+   refinement to the maths, and no free dataset carries it.
+
+## The scouting layer
+
+The `Scouting` tab and `footy/analysis.py` exist because the obvious way to do
+this analysis is subtly wrong in three places.
+
+**Season card leaders are mostly a schedule table.** A team near the top of the
+raw list often got there by playing the six most aggressive sides away from
+home, or by trailing in half its matches — losing teams chase, foul and get
+booked. `discipline_table` divides each team's actual cards by what the model
+expected for those exact fixtures and referees. A ratio above 1.0 is a team that
+is genuinely dirtier than its schedule implies. The `signal` column marks
+whether the gap exceeds two Poisson standard errors; on a full season most teams
+come back as noise, which is the honest answer.
+
+**Six matches is not a sample.** At roughly two cards a side per game, the
+standard error on a six-match average is about 0.6 — larger than the real
+spread between most teams. `recent_form` shows the raw average and the shrunk
+one side by side. The shrunk number is the one to use. The model itself never
+uses a "last six" window at all; exponential time decay weights every past match
+continuously, which is the same idea done properly.
+
+**Home and away splits are real but small.** Away sides take roughly 10-15% more
+cards, and that is a league-wide effect, not a per-team one. Fitting a separate
+home and away rating for every team doubles your parameters and halves the data
+behind each. The model fits one home advantage per league instead, which is more
+reliable, and `season_table` still gives you the per-team split to eyeball.
+
+**Referees are the exception — that signal is real.** `referee_table` gives you
+cards per match, booking points, reds, the home/away card split, and fouls per
+card, which separates the officials who talk to players from the ones who reach
+for the pocket. Appointments are published two or three days before kickoff
+(PGMOL for the Premier League, the national federations elsewhere) and prices
+often do not fully move for them.
+
+### Extending the same thinking to goals, corners and results
+
+The useful generalisation is that **cards and corners are consequences of match
+shape, not independent events**, so the goals model should inform them:
+
+- A big mismatch means the favourite camps in the opposition half. Corner totals
+  rise and tilt heavily to one side.
+- A big mismatch also means a less contested game, so fewer tactical fouls and
+  fewer bookings.
+- Two evenly matched sides in a tight, low-scoring game is where cards live.
+
+`footy/context.py` fits exactly this: it regresses the corner and card models'
+residuals on expected supremacy and expected total goals, both of which the
+goals model already produces. Two coefficients each. Run it, print `describe()`,
+and check the signs match the story above. On data with no such effect the
+coefficients come back near zero and R² near zero, which is the behaviour you
+want from something that could otherwise fit noise.
+
+Three more effects in the same family, worth adding next:
+
+1. **Rest days.** `analysis.rest_days` computes them. Under four days between
+   matches measurably drags expected goals down, and midweek European fixtures
+   are the usual cause. This is the most under-priced schedule effect in
+   football because it is invisible in a form table.
+2. **Game state.** Half-time scores are in the data (`HTHG`, `HTAG`). Teams
+   trailing at the break take more cards and win more corners in the second
+   half. You can measure the size of that in your own league in about ten lines.
+3. **Motivation late in the season.** A mid-table side with nothing to play for
+   in May is a different team from the one that played in October, and no rating
+   model built on results alone will notice.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,445 @@
+"""Football Edge - a dashboard for pricing matches against the book.
+
+Run with:  streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from footy import analysis as an
+from footy import backtest, data
+from footy.betting import devig_power, find_value, kelly
+from footy.brief import format_brief, match_brief, slate_scan
+from footy.predict import fit_league, predict_match
+
+st.set_page_config(page_title="Football Edge", layout="wide",
+                   initial_sidebar_state="expanded")
+
+# --- Visual system ----------------------------------------------------------
+# Pools-coupon palette: grey-green paper, slate ink, one green for edge.
+CSS = """
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap');
+
+:root {
+  --paper:#EDEEE8; --panel:#FFFFFF; --ink:#1B2A32; --muted:#6E7A80;
+  --rule:#CDD0C6; --edge:#0F7350; --warn:#9C3B33; --market:#4A6572;
+}
+html, body, [class*="css"], .stApp { background:var(--paper); color:var(--ink);
+  font-family:'Archivo',system-ui,sans-serif; font-variant-numeric:tabular-nums; }
+h1,h2,h3 { font-family:'Archivo',sans-serif; letter-spacing:-.02em;
+  font-weight:600; color:var(--ink); }
+h1 { font-size:2.1rem; margin-bottom:.1rem; }
+.sub { color:var(--muted); font-size:.92rem; margin-bottom:1.4rem; }
+
+.fixture { background:var(--panel); border:1px solid var(--rule);
+  padding:14px 16px; margin-bottom:10px; }
+.fx-head { display:flex; justify-content:space-between; align-items:baseline;
+  border-bottom:1px solid var(--rule); padding-bottom:8px; margin-bottom:10px; }
+.fx-teams { font-size:1.05rem; font-weight:600; }
+.fx-meta { color:var(--muted); font-size:.82rem; }
+
+/* The signature element: model probability as a bar, market as a tick. */
+.row { display:grid; grid-template-columns:150px 1fr 62px 62px;
+  align-items:center; gap:12px; padding:5px 0; font-size:.86rem; }
+.sel { color:var(--ink); }
+.track { position:relative; height:9px; background:#E2E4DC; }
+.bar { position:absolute; left:0; top:0; bottom:0; background:var(--market); }
+.bar.value { background:var(--edge); }
+.tick { position:absolute; top:-4px; bottom:-4px; width:2px;
+  background:var(--ink); }
+.num { text-align:right; color:var(--muted); }
+.num.pos { color:var(--edge); font-weight:600; }
+
+.bet { border-left:3px solid var(--edge); background:var(--panel);
+  padding:10px 14px; margin-bottom:8px; }
+.bet .big { font-weight:600; }
+.note { background:#E4E7DE; border-left:3px solid var(--market);
+  padding:10px 14px; font-size:.86rem; color:var(--ink); margin-bottom:14px; }
+[data-testid="stSidebar"] { background:#E4E6DE; border-right:1px solid var(--rule); }
+</style>
+"""
+st.markdown(CSS, unsafe_allow_html=True)
+
+
+# --- Data and models --------------------------------------------------------
+@st.cache_data(show_spinner="Downloading match history…", ttl=60 * 60 * 6)
+def get_history(divs: tuple, start_year: int, n_seasons: int) -> pd.DataFrame:
+    return data.load_history(divs, start_year, n_seasons)
+
+
+@st.cache_resource(show_spinner="Fitting models…")
+def get_models(_df: pd.DataFrame, div: str, stamp: str):
+    return fit_league(_df, div)
+
+
+@st.cache_data(ttl=60 * 30, show_spinner=False)
+def get_fixtures(divs: tuple) -> pd.DataFrame:
+    return data.load_fixtures(divs)
+
+
+def bar_row(label: str, p: float, odds: float | None,
+            market_p: float | None = None) -> str:
+    """One selection: model bar, market tick, price, edge."""
+    ev = (p * odds - 1) if odds and np.isfinite(odds) else None
+    value = ev is not None and ev > 0
+    tick = (f'<div class="tick" style="left:{min(market_p,1)*100:.1f}%"></div>'
+            if market_p else "")
+    ev_txt = f"{ev*100:+.1f}%" if ev is not None else "—"
+    return (
+        f'<div class="row"><div class="sel">{label}</div>'
+        f'<div class="track"><div class="bar {"value" if value else ""}" '
+        f'style="width:{min(p,1)*100:.1f}%"></div>{tick}</div>'
+        f'<div class="num">{p*100:.1f}%</div>'
+        f'<div class="num {"pos" if value else ""}">{ev_txt}</div></div>'
+    )
+
+
+# --- Sidebar ----------------------------------------------------------------
+st.sidebar.markdown("### Setup")
+league_names = st.sidebar.multiselect(
+    "Leagues", list(data.LEAGUES.values()),
+    default=["Premier League", "La Liga", "Serie A", "Bundesliga", "Ligue 1"])
+divs = tuple(k for k, v in data.LEAGUES.items() if v in league_names) or ("E0",)
+
+n_seasons = st.sidebar.slider("Seasons of history", 3, 10, 7)
+latest_season = data.current_season_start()
+start_year = st.sidebar.number_input(
+    "First season starts", 2010, latest_season,
+    latest_season - int(n_seasons) + 1,
+    help="Defaults so the window ends at the season now in progress.")
+
+st.sidebar.markdown("### Betting rules")
+min_edge = st.sidebar.slider("Minimum edge to bet", 0.0, 0.20, 0.05, 0.01,
+                             help="Your probabilities have error. Betting a 1% "
+                                  "modelled edge is betting on your own noise.")
+blend_w = st.sidebar.slider("Blend toward market (1X2)", 0.0, 1.0, 0.35, 0.05,
+                            help="0 trusts the model alone. These leagues are "
+                                 "very efficient, so some shrinkage usually "
+                                 "improves calibration.")
+frac = st.sidebar.slider("Kelly fraction", 0.05, 1.0, 0.25, 0.05)
+bankroll = st.sidebar.number_input("Bankroll", 50, 1_000_000, 1000, step=50)
+
+if st.sidebar.button("Clear cached data"):
+    st.cache_data.clear()
+    st.cache_resource.clear()
+    st.rerun()
+
+st.markdown("# Football Edge")
+st.markdown('<div class="sub">Model prices versus bookmaker prices. '
+            'The bar is the model, the tick is the market. Bet the gap.</div>',
+            unsafe_allow_html=True)
+
+try:
+    hist = get_history(divs, int(start_year), int(n_seasons))
+except Exception as exc:
+    st.error(f"Could not load data: {exc}")
+    st.stop()
+
+stamp = str(hist["Date"].max().date())
+tab_week, tab_match, tab_scout, tab_test = st.tabs(
+    ["This week", "Price a match", "Scouting", "Backtest"])
+
+
+# --- Tab 1: upcoming fixtures ----------------------------------------------
+with tab_week:
+    try:
+        fx = get_fixtures(divs)
+    except Exception as exc:
+        st.warning(f"Fixture list unavailable: {exc}")
+        fx = pd.DataFrame()
+
+    if fx.empty:
+        st.info("No upcoming fixtures published for these leagues right now. "
+                "football-data posts them a few days before each round.")
+    else:
+        st.caption(f"{len(fx)} fixtures · models trained through {stamp}")
+        all_bets = []
+        for div in fx["Div"].unique():
+            try:
+                lm = get_models(hist, div, stamp)
+            except Exception as exc:
+                st.warning(f"{div}: {exc}")
+                continue
+
+            for _, row in fx[fx["Div"] == div].iterrows():
+                pred = predict_match(lm, row["HomeTeam"], row["AwayTeam"],
+                                     referee=row.get("Referee"),
+                                     market_odds=row.to_dict(),
+                                     blend_1x2=blend_w)
+                p = pred["probs"]
+                odds = {k: row.get(c) for k, c in
+                        [("home", "odds_h"), ("draw", "odds_d"),
+                         ("away", "odds_a"), ("over_2.5", "odds_o25"),
+                         ("under_2.5", "odds_u25")]}
+                fair = None
+                if all(odds.get(k) for k in ("home", "draw", "away")):
+                    fair = dict(zip(["home", "draw", "away"],
+                                    devig_power([odds["home"], odds["draw"],
+                                                 odds["away"]])))
+
+                labels = {"home": row["HomeTeam"], "draw": "Draw",
+                          "away": row["AwayTeam"],
+                          "over_2.5": "Over 2.5 goals",
+                          "under_2.5": "Under 2.5 goals"}
+                rows_html = "".join(
+                    bar_row(labels[k], p[k], odds.get(k),
+                            fair.get(k) if fair else None)
+                    for k in labels if k in p)
+
+                date_txt = (row["Date"].strftime("%a %d %b")
+                            if pd.notna(row["Date"]) else "")
+                ref_txt = (f' · ref {row["Referee"]}'
+                           if pd.notna(row.get("Referee")) else "")
+                st.markdown(
+                    f'<div class="fixture"><div class="fx-head">'
+                    f'<div class="fx-teams">{row["HomeTeam"]} v {row["AwayTeam"]}</div>'
+                    f'<div class="fx-meta">{data.LEAGUES.get(div, div)} · {date_txt} · '
+                    f'xG {pred["xg_home"]}–{pred["xg_away"]} · '
+                    f'corners {pred.get("exp_corners","–")} · '
+                    f'cards {pred.get("exp_cards","–")}{ref_txt}</div></div>'
+                    f'{rows_html}</div>', unsafe_allow_html=True)
+
+                for b in find_value(p, {k: v for k, v in odds.items() if v},
+                                    min_edge=min_edge, fraction=frac):
+                    b["match"] = f'{row["HomeTeam"]} v {row["AwayTeam"]}'
+                    b["selection"] = labels.get(b["selection"], b["selection"])
+                    all_bets.append(b)
+
+        with st.expander("Scan the whole slate"):
+            st.markdown('<div class="note">Sorting the matchday by expected '
+                        'cards or corners and reading the top and bottom five '
+                        'finds a mispriced game faster than opening twenty '
+                        'briefs in fixture order.</div>',
+                        unsafe_allow_html=True)
+            scan_metric = st.selectbox("Sort by", ["cards", "corners", "goals"],
+                                       key="scanmetric")
+            models = {}
+            for dv in fx["Div"].unique():
+                try:
+                    models[dv] = get_models(hist, dv, stamp)
+                except Exception:
+                    pass
+            st.dataframe(slate_scan(hist, models, fx, scan_metric),
+                         hide_index=True, width="stretch")
+
+        st.markdown("### Selections clearing your threshold")
+        if not all_bets:
+            st.markdown('<div class="note">Nothing qualifies. That is the '
+                        'normal result — most weeks the book is right and the '
+                        'correct action is no bet.</div>',
+                        unsafe_allow_html=True)
+        else:
+            for b in sorted(all_bets, key=lambda x: -x["edge"]):
+                st.markdown(
+                    f'<div class="bet"><span class="big">{b["selection"]}</span>'
+                    f' — {b["match"]}<br>'
+                    f'<span class="fx-meta">Price {b["odds"]} · fair '
+                    f'{b["fair_odds"]} · edge {b["edge"]*100:.1f}% · stake '
+                    f'{b["stake_pct"]}% of bankroll '
+                    f'({bankroll * b["stake_pct"] / 100:.0f})</span></div>',
+                    unsafe_allow_html=True)
+
+
+# --- Tab 2: manual pricing --------------------------------------------------
+with tab_match:
+    st.markdown('<div class="note">football-data carries odds for match result '
+                'and over/under 2.5 only. For corners and cards, read the price '
+                'off your bookmaker and type it in here.</div>',
+                unsafe_allow_html=True)
+
+    div = st.selectbox("League", divs,
+                       format_func=lambda d: data.LEAGUES.get(d, d))
+    lm = get_models(hist, div, stamp)
+    teams = lm.goals.teams
+    c1, c2, c3 = st.columns(3)
+    home = c1.selectbox("Home", teams, index=0)
+    away = c2.selectbox("Away", teams, index=min(1, len(teams) - 1))
+    refs = sorted(lm.cards.ref_factor) if lm.cards else []
+    ref = c3.selectbox("Referee", ["(unknown)"] + refs)
+    ref = None if ref == "(unknown)" else ref
+
+    if home == away:
+        st.warning("Pick two different teams.")
+    else:
+        pred = predict_match(lm, home, away, referee=ref, blend_1x2=0.0)
+        p = pred["probs"]
+
+        m1, m2, m3, m4 = st.columns(4)
+        m1.metric("Expected goals", f'{pred["xg_home"]}–{pred["xg_away"]}')
+        m2.metric("Expected corners", pred.get("exp_corners", "–"))
+        m3.metric("Expected cards", pred.get("exp_cards", "–"))
+        m4.metric("Referee factor", pred.get("ref_factor") or "–")
+
+        with st.expander("Full match brief", expanded=True):
+            st.markdown(format_brief(
+                match_brief(hist, lm, home, away, referee=ref, n=6)))
+
+        st.markdown("#### Enter the prices you can actually get")
+        selections = {
+            home: "home", "Draw": "draw", away: "away",
+            "Over 2.5 goals": "over_2.5", "Under 2.5 goals": "under_2.5",
+            "Both teams to score": "btts_yes",
+            "Over 9.5 corners": "corners_over_9.5",
+            "Over 10.5 corners": "corners_over_10.5",
+            "Over 3.5 cards": "cards_over_3.5",
+            "Over 4.5 cards": "cards_over_4.5",
+            "Over 35.5 booking points": "points_over_35.5",
+        }
+        entered = {}
+        cols = st.columns(3)
+        for i, (label, key) in enumerate(selections.items()):
+            if key not in p:
+                continue
+            v = cols[i % 3].number_input(
+                f'{label}  ·  fair {1/max(p[key],1e-6):.2f}',
+                min_value=0.0, max_value=50.0, value=0.0, step=0.05,
+                key=f"odds_{key}")
+            if v > 1.0:
+                entered[key] = v
+
+        if entered:
+            bets = find_value(p, entered, min_edge=min_edge, fraction=frac)
+            st.markdown("#### Verdict")
+            if not bets:
+                st.markdown('<div class="note">No selection clears your '
+                            'threshold at those prices.</div>',
+                            unsafe_allow_html=True)
+            rev = {v: k for k, v in selections.items()}
+            for b in bets:
+                st.markdown(
+                    f'<div class="bet"><span class="big">'
+                    f'{rev.get(b["selection"], b["selection"])}</span> at '
+                    f'{b["odds"]}<br><span class="fx-meta">Model '
+                    f'{b["model_prob"]*100:.1f}% · fair {b["fair_odds"]} · '
+                    f'edge {b["edge"]*100:.1f}% · stake '
+                    f'{bankroll * b["stake_pct"] / 100:.0f}</span></div>',
+                    unsafe_allow_html=True)
+
+        with st.expander("Most likely scorelines"):
+            st.dataframe(pd.DataFrame(pred["top_scores"],
+                                      columns=["Score", "Probability"]),
+                         hide_index=True, width="stretch")
+
+
+# --- Tab 3: scouting tables -------------------------------------------------
+with tab_scout:
+    s_div = st.selectbox("League  ", divs, key="scoutdiv",
+                         format_func=lambda d: data.LEAGUES.get(d, d))
+    sd = hist[hist["Div"] == s_div]
+    slm = get_models(hist, s_div, stamp)
+    seasons = sorted(sd["season"].astype(str).unique())
+    season = st.selectbox("Season", ["All"] + seasons,
+                          index=len(seasons))
+    season_arg = None if season == "All" else season
+
+    st.markdown("#### Discipline, adjusted for schedule")
+    st.markdown('<div class="note">The raw card table mostly ranks teams by who '
+                'they played and how often they were losing. This divides actual '
+                'cards by what the model expected for those exact fixtures. '
+                'Ratio above 1.0 means dirtier than the schedule implies — and '
+                'the signal column tells you whether the gap is bigger than '
+                'Poisson noise. Most of them are not.</div>',
+                unsafe_allow_html=True)
+    try:
+        disc = an.discipline_table(sd, slm.cards, season_arg)
+        st.dataframe(disc.reset_index(), hide_index=True, width="stretch")
+    except Exception as exc:
+        st.warning(str(exc))
+
+    c1, c2 = st.columns(2)
+    with c1:
+        st.markdown("#### Season totals by venue")
+        metric = st.selectbox("Metric", ["cards", "corners", "goals", "points",
+                                         "fouls", "yellow"])
+        try:
+            st.dataframe(an.season_table(sd, metric, season_arg).reset_index(),
+                         hide_index=True, width="stretch")
+        except Exception as exc:
+            st.warning(str(exc))
+    with c2:
+        st.markdown("#### Referees")
+        st.markdown('<div class="note">Officials are usually announced two or '
+                    'three days before kickoff. The factor column is the '
+                    'shrunk multiplier the card model applies.</div>',
+                    unsafe_allow_html=True)
+        rt = an.referee_table(sd, slm.cards, min_matches=8)
+        st.dataframe(rt.reset_index(), hide_index=True, width="stretch")
+
+    st.markdown("#### Recent form, raw against shrunk")
+    st.markdown('<div class="note">Six matches of card counts is close to pure '
+                'noise: the standard error on a six-match average is bigger '
+                'than any real difference between two teams. Compare the two '
+                'columns before trusting a hot streak.</div>',
+                unsafe_allow_html=True)
+    f1, f2, f3 = st.columns(3)
+    team = f1.selectbox("Team", slm.goals.teams)
+    fmetric = f2.selectbox("Metric ", ["cards", "corners", "goals"])
+    fvenue = f3.selectbox("Venue", ["all", "home", "away"])
+    form = an.recent_form(sd, team, fmetric, n=6,
+                          venue=None if fvenue == "all" else fvenue)
+    g1, g2, g3 = st.columns(3)
+    g1.metric("Last 6 average", form["recent_avg"])
+    g2.metric("Long-run average", form["long_run_avg"])
+    g3.metric("Use this", form["shrunk"])
+    st.dataframe(form["log"], hide_index=True, width="stretch")
+
+    if slm.ctx_corners or slm.ctx_cards:
+        with st.expander("How match shape moves corners and cards"):
+            st.markdown("A one-sided match means the favourite camps in the "
+                        "opposition half, so corners rise and tilt to one side, "
+                        "while a less contested game produces fewer bookings. "
+                        "These coefficients are fitted from your data, not "
+                        "assumed. If the signs contradict that story, the "
+                        "effect is not in your league and the adjustment is "
+                        "doing nothing useful.")
+            for c in (slm.ctx_corners, slm.ctx_cards):
+                if c:
+                    st.code(c.describe())
+
+
+# --- Tab 4: backtest --------------------------------------------------------
+with tab_test:
+    st.markdown('<div class="note">Refits the model every N days using only '
+                'matches already played, then prices the fixtures ahead of it. '
+                'Judge it on return on investment and on the calibration table, '
+                'never on hit rate.</div>', unsafe_allow_html=True)
+
+    b1, b2, b3 = st.columns(3)
+    bt_div = b1.selectbox("League ", divs, key="btdiv",
+                          format_func=lambda d: data.LEAGUES.get(d, d))
+    default_start = (hist["Date"].max() - pd.Timedelta(days=540)).date()
+    bt_start = b2.date_input("Test from", default_start)
+    refit = b3.slider("Refit every (days)", 3, 30, 7)
+
+    if st.button("Run backtest"):
+        with st.spinner("Walking forward…"):
+            try:
+                log, summary = backtest.run(
+                    hist, bt_div, str(bt_start), refit_days=refit,
+                    min_edge=min_edge, blend_1x2=blend_w, fraction=frac,
+                    bankroll=float(bankroll))
+            except Exception as exc:
+                st.error(str(exc))
+                st.stop()
+
+        if log.empty:
+            st.info(summary.get("note", "No qualifying bets."))
+        else:
+            k = list(summary.items())
+            cols = st.columns(5)
+            for i, (name, val) in enumerate(k[:10]):
+                cols[i % 5].metric(name.replace("_", " "), val)
+            st.line_chart(log.set_index("date")["bankroll"])
+            st.markdown("#### Calibration")
+            log["bucket"] = pd.cut(log["model_prob"], np.linspace(0, 1, 11))
+            cal = (log.groupby("bucket", observed=True)
+                   .agg(bets=("won", "size"), predicted=("model_prob", "mean"),
+                        actual=("won", "mean")).round(3).reset_index())
+            st.dataframe(cal, hide_index=True, width="stretch")
+            st.markdown("#### Every bet")
+            st.dataframe(log.drop(columns=["bucket"]), hide_index=True,
+                         width="stretch")

--- a/footy/__init__.py
+++ b/footy/__init__.py
@@ -1,0 +1,5 @@
+from . import (analysis, backtest, betting, brief, context, data,  # noqa: F401
+               markets, predict, ratings)
+
+__all__ = ["data", "ratings", "markets", "betting", "predict", "backtest",
+           "analysis", "context", "brief"]

--- a/footy/analysis.py
+++ b/footy/analysis.py
@@ -1,0 +1,222 @@
+"""Scouting tables - the descriptive layer that sits under the model.
+
+The organising trick is `to_team_rows`: reshape one row per match into two rows
+per match, one from each team's point of view. Every table below is then a
+groupby on that, which keeps home/away splits honest and makes it impossible to
+accidentally mix a team's attacking and defending numbers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def to_team_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """One row per team per match, from that team's perspective."""
+    def side(home: bool) -> pd.DataFrame:
+        p, o = ("H", "A") if home else ("A", "H")
+        out = pd.DataFrame({
+            "Div": df["Div"], "Date": df["Date"], "season": df.get("season"),
+            "team": df["HomeTeam" if home else "AwayTeam"],
+            "opponent": df["AwayTeam" if home else "HomeTeam"],
+            "venue": "home" if home else "away",
+            "referee": df.get("Referee"),
+            "goals_for": df[f"FT{p}G"], "goals_against": df[f"FT{o}G"],
+        })
+        for name, col in [("corners", "C"), ("shots", "S"), ("sot", "ST"),
+                          ("fouls", "F"), ("yellow", "Y"), ("red", "R")]:
+            if f"{p}{col}" in df.columns:
+                out[f"{name}_for"] = df[f"{p}{col}"]
+                out[f"{name}_against"] = df[f"{o}{col}"]
+        if "yellow_for" in out.columns:
+            out["cards_for"] = out["yellow_for"].fillna(0) + out["red_for"].fillna(0)
+            out["cards_against"] = (out["yellow_against"].fillna(0)
+                                    + out["red_against"].fillna(0))
+            out["points_for"] = (10 * out["yellow_for"].fillna(0)
+                                 + 25 * out["red_for"].fillna(0))
+            # season_table asks for both sides of every metric, so booking
+            # points need the conceded column too.
+            out["points_against"] = (10 * out["yellow_against"].fillna(0)
+                                     + 25 * out["red_against"].fillna(0))
+        if "corners_for" in out.columns:
+            out["corners_total"] = out["corners_for"] + out["corners_against"]
+        out["result"] = np.where(out["goals_for"] > out["goals_against"], "W",
+                         np.where(out["goals_for"] < out["goals_against"], "L", "D"))
+        return out
+
+    return (pd.concat([side(True), side(False)])
+            .sort_values("Date").reset_index(drop=True))
+
+
+def shrink(observed: float, n: int, prior: float, prior_n: float = 12.0) -> float:
+    """Pull a small-sample rate toward a long-run rate.
+
+    Six matches of card counts is almost pure noise: at two cards a game the
+    standard error on a six-match average is about 0.6 cards, which is bigger
+    than any real difference between two teams. This weights the recent number
+    by how much of it you can actually believe.
+    """
+    if n <= 0 or not np.isfinite(observed):
+        return prior
+    w = n / (n + prior_n)
+    return float(w * observed + (1 - w) * prior)
+
+
+def season_table(df: pd.DataFrame, metric: str = "cards",
+                 season: str | None = None) -> pd.DataFrame:
+    """Season totals for one metric, split by venue.
+
+    `metric` is one of cards, points, corners, goals, fouls, yellow.
+    Read this for context, not for prediction — see `discipline_table` for the
+    version that adjusts for who each team actually played.
+    """
+    tr = to_team_rows(df)
+    if season is not None:
+        tr = tr[tr["season"].astype(str) == str(season)]
+    f, a = f"{metric}_for", f"{metric}_against"
+    if f not in tr.columns:
+        raise ValueError(f"No column for metric '{metric}'.")
+
+    g = tr.groupby("team")
+    out = pd.DataFrame({
+        "matches": g.size(),
+        "for": g[f].sum(),
+        "against": g[a].sum(),
+        "per_match": g[f].mean().round(2),
+    })
+    for v in ("home", "away"):
+        sub = tr[tr["venue"] == v].groupby("team")[f]
+        out[f"{v}_per_match"] = sub.mean().round(2)
+    out["home_away_gap"] = (out["away_per_match"] - out["home_per_match"]).round(2)
+    return out.sort_values("for", ascending=False)
+
+
+def discipline_table(df: pd.DataFrame, model, season: str | None = None
+                     ) -> pd.DataFrame:
+    """Cards above or below what the fixtures alone would predict.
+
+    A raw card table mostly ranks teams by who they played and how often they
+    were losing. This divides each team's actual cards by the model's
+    expectation for those specific matches, so a ratio above 1.0 means genuinely
+    dirtier than their schedule implies. This is the column to bet off.
+    """
+    tr = to_team_rows(df)
+    if season is not None:
+        tr = tr[tr["season"].astype(str) == str(season)]
+    if "cards_for" not in tr.columns:
+        raise ValueError("No card data in this dataset.")
+
+    exp = []
+    for _, r in tr.iterrows():
+        if r["venue"] == "home":
+            e, _o = model.expected(r["team"], r["opponent"], referee=r.get("referee"))
+        else:
+            _o, e = model.expected(r["opponent"], r["team"], referee=r.get("referee"))
+        exp.append(e)
+    tr["expected"] = exp
+
+    g = tr.groupby("team")
+    out = pd.DataFrame({
+        "matches": g.size(),
+        "actual": g["cards_for"].sum().round(1),
+        "expected": g["expected"].sum().round(1),
+    })
+    out["ratio"] = (out["actual"] / out["expected"]).round(2)
+    out["per_match"] = (out["actual"] / out["matches"]).round(2)
+    # Poisson standard error on the ratio, so you can see what is real.
+    out["se"] = (np.sqrt(out["actual"].clip(lower=1)) / out["expected"]).round(2)
+    out["signal"] = np.where(
+        (out["ratio"] - 1).abs() > 2 * out["se"], "real", "noise")
+    return out.sort_values("ratio", ascending=False)
+
+
+def recent_form(df: pd.DataFrame, team: str, metric: str = "cards",
+                n: int = 6, venue: str | None = None,
+                long_run_matches: int = 60) -> dict:
+    """Last n matches for one team, with the shrunk estimate beside the raw one.
+
+    The raw average is what most tipsters quote. The shrunk one is what you
+    should actually use.
+    """
+    tr = to_team_rows(df)
+    tr = tr[tr["team"] == team]
+    f = f"{metric}_for"
+    if f not in tr.columns:
+        raise ValueError(f"No column for metric '{metric}'.")
+
+    long_run = tr.tail(long_run_matches)[f].mean()
+    sub = tr if venue is None else tr[tr["venue"] == venue]
+    last = sub.tail(n)
+    raw = last[f].mean()
+
+    return {
+        "team": team, "metric": metric, "venue": venue or "all",
+        "matches": len(last),
+        "recent_avg": round(float(raw), 2) if len(last) else None,
+        "long_run_avg": round(float(long_run), 2) if len(tr) else None,
+        "shrunk": round(shrink(raw, len(last), long_run), 2) if len(tr) else None,
+        "log": last[["Date", "opponent", "venue", "result", f,
+                     f"{metric}_against"]].reset_index(drop=True),
+    }
+
+
+def referee_table(df: pd.DataFrame, model=None, min_matches: int = 8
+                  ) -> pd.DataFrame:
+    """Every referee's card rate, and how it compares to expectation.
+
+    `factor` is the number that matters. 1.20 means this official books 20%
+    more than the teams in front of him would otherwise produce. Officials are
+    usually announced two or three days before kickoff, and the market is often
+    slow to reprice for them.
+    """
+    d = df.dropna(subset=["Referee"]).copy()
+    if d.empty:
+        return pd.DataFrame()
+    d["cards"] = (d["HY"].fillna(0) + d["AY"].fillna(0)
+                  + d["HR"].fillna(0) + d["AR"].fillna(0))
+    d["points"] = (10 * (d["HY"].fillna(0) + d["AY"].fillna(0))
+                   + 25 * (d["HR"].fillna(0) + d["AR"].fillna(0)))
+    d["fouls"] = d.get("HF", 0) + d.get("AF", 0)
+
+    g = d.groupby("Referee")
+    out = pd.DataFrame({
+        "matches": g.size(),
+        "cards_per_match": g["cards"].mean().round(2),
+        "points_per_match": g["points"].mean().round(1),
+        "home_cards": (g["HY"].mean() + g["HR"].mean()).round(2),
+        "away_cards": (g["AY"].mean() + g["AR"].mean()).round(2),
+        "reds_per_match": (g["HR"].mean() + g["AR"].mean()).round(3),
+    })
+    if "HF" in d.columns:
+        out["fouls_per_card"] = (g["fouls"].mean() / g["cards"].mean()).round(1)
+    out["home_bias"] = (out["away_cards"] - out["home_cards"]).round(2)
+
+    if model is not None and model.ref_factor:
+        out["factor"] = pd.Series(model.ref_factor)
+    out = out[out["matches"] >= min_matches]
+    return out.sort_values("cards_per_match", ascending=False)
+
+
+def head_to_head(df: pd.DataFrame, home: str, away: str, n: int = 8
+                 ) -> pd.DataFrame:
+    """Recent meetings. Useful context, weak evidence — squads turn over."""
+    m = df[((df["HomeTeam"] == home) & (df["AwayTeam"] == away))
+           | ((df["HomeTeam"] == away) & (df["AwayTeam"] == home))]
+    cols = [c for c in ["Date", "HomeTeam", "AwayTeam", "FTHG", "FTAG",
+                        "HC", "AC", "HY", "AY", "HR", "AR", "Referee"]
+            if c in m.columns]
+    return m.sort_values("Date", ascending=False).head(n)[cols].reset_index(drop=True)
+
+
+def rest_days(df: pd.DataFrame) -> pd.DataFrame:
+    """Days since each team's previous match.
+
+    Short turnarounds are the most under-priced schedule effect in football:
+    fewer than four days between matches measurably drags a team's expected
+    goals down, and midweek European fixtures are the usual cause.
+    """
+    tr = to_team_rows(df)
+    tr["rest"] = tr.groupby("team")["Date"].diff().dt.days
+    return tr[["Date", "team", "opponent", "venue", "rest", "goals_for",
+               "goals_against"]]

--- a/footy/backtest.py
+++ b/footy/backtest.py
@@ -1,0 +1,130 @@
+"""Walk-forward backtest.
+
+The model is refitted every `refit_days` using only matches that had already
+been played, then asked to price the fixtures ahead of it. Any backtest that
+shuffles rows into random train/test splits is leaking the future and will
+show you a profit that does not exist.
+
+The numbers that matter here are ROI and closing-line value, not accuracy.
+A model can pick 55% of winners and still lose money.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .betting import expected_value, kelly
+from .predict import fit_league, predict_match
+
+MARKETS_1X2 = {"home": "odds_h", "draw": "odds_d", "away": "odds_a"}
+MARKETS_OU = {"over_2.5": "odds_o25", "under_2.5": "odds_u25"}
+
+
+def run(df: pd.DataFrame,
+        div: str,
+        start: str,
+        end: str | None = None,
+        *,
+        refit_days: int = 7,
+        min_edge: float = 0.04,
+        blend_1x2: float = 0.35,
+        fraction: float = 0.25,
+        bankroll: float = 1000.0) -> tuple[pd.DataFrame, dict]:
+    d = df[df["Div"] == div].sort_values("Date").reset_index(drop=True)
+    start_ts = pd.Timestamp(start)
+    end_ts = pd.Timestamp(end) if end else d["Date"].max()
+    window = d[(d["Date"] >= start_ts) & (d["Date"] <= end_ts)]
+    if window.empty:
+        raise ValueError("No matches in that date range.")
+
+    bets = []
+    bank = bankroll
+    lm = None
+    last_fit = None
+
+    for date, day in window.groupby(window["Date"].dt.normalize()):
+        if last_fit is None or (date - last_fit).days >= refit_days:
+            try:
+                lm = fit_league(d, div, as_of=date)
+                last_fit = date
+            except ValueError:
+                continue
+        if lm is None:
+            continue
+
+        for _, row in day.iterrows():
+            odds = {k: row.get(v) for k, v in
+                    {**MARKETS_1X2, **MARKETS_OU}.items()}
+            pred = predict_match(lm, row["HomeTeam"], row["AwayTeam"],
+                                 referee=row.get("Referee"),
+                                 market_odds=row.to_dict(),
+                                 blend_1x2=blend_1x2)
+            p = pred["probs"]
+
+            total = row["FTHG"] + row["FTAG"]
+            result = ("home" if row["FTHG"] > row["FTAG"]
+                      else "away" if row["FTHG"] < row["FTAG"] else "draw")
+            won = {**{k: (k == result) for k in MARKETS_1X2},
+                   "over_2.5": total > 2.5, "under_2.5": total < 2.5}
+
+            for sel, o in odds.items():
+                if o is None or not np.isfinite(o) or o < 1.3 or o > 8:
+                    continue
+                ev = expected_value(p[sel], o)
+                if ev < min_edge:
+                    continue
+                stake = kelly(p[sel], o, fraction) * bank
+                if stake < 0.5:
+                    continue
+                profit = stake * (o - 1) if won[sel] else -stake
+                bank += profit
+                bets.append({
+                    "date": row["Date"], "home": row["HomeTeam"],
+                    "away": row["AwayTeam"], "selection": sel,
+                    "model_prob": p[sel], "odds": o, "edge": ev,
+                    "stake": stake, "won": bool(won[sel]),
+                    "profit": profit, "bankroll": bank,
+                })
+
+    log = pd.DataFrame(bets)
+    if log.empty:
+        return log, {"n_bets": 0, "note": "No bets cleared the edge threshold."}
+
+    staked = log["stake"].sum()
+    summary = {
+        "n_bets": len(log),
+        "hit_rate": round(log["won"].mean(), 4),
+        "total_staked": round(staked, 2),
+        "profit": round(log["profit"].sum(), 2),
+        "roi_pct": round(100 * log["profit"].sum() / staked, 2),
+        "yield_per_bet_pct": round(100 * log["profit"].sum() / len(log)
+                                   / log["stake"].mean(), 2),
+        "final_bankroll": round(bank, 2),
+        "max_drawdown_pct": round(_max_dd(log["bankroll"]) * 100, 2),
+        "avg_odds": round(log["odds"].mean(), 2),
+        "avg_edge_pct": round(100 * log["edge"].mean(), 2),
+    }
+    return log, summary
+
+
+def _max_dd(series: pd.Series) -> float:
+    peak = series.cummax()
+    return float(((peak - series) / peak).max())
+
+
+def calibration(df: pd.DataFrame, div: str, start: str, bins: int = 10,
+                **kw) -> pd.DataFrame:
+    """Are 30% shots actually winning 30% of the time?
+
+    This is the single most useful diagnostic. If your 60% bucket wins 48%,
+    no staking plan will save you.
+    """
+    log, _ = run(df, div, start, min_edge=-1.0, **kw)
+    if log.empty:
+        return log
+    log["bucket"] = pd.cut(log["model_prob"], np.linspace(0, 1, bins + 1))
+    return (log.groupby("bucket", observed=True)
+            .agg(n=("won", "size"), predicted=("model_prob", "mean"),
+                 actual=("won", "mean"))
+            .round(3).reset_index())

--- a/footy/betting.py
+++ b/footy/betting.py
@@ -1,0 +1,106 @@
+"""Odds, margin removal, expected value and stake sizing.
+
+This is the part that decides whether you bet, and it matters more than the
+model. A model that is 2% better than the market makes money; the same model
+staked badly does not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def implied(odds) -> np.ndarray:
+    return 1.0 / np.asarray(odds, dtype=float)
+
+
+def overround(odds) -> float:
+    """Bookmaker margin. 1.05 means a 5% book."""
+    return float(implied(odds).sum())
+
+
+def devig_power(odds, tol: float = 1e-10) -> np.ndarray:
+    """Remove the margin with the power method.
+
+    Better than dividing by the overround, which over-corrects favourites and
+    under-corrects longshots. Solves for k in sum(p_i^k) = 1.
+    """
+    p = implied(odds)
+    lo, hi = 0.5, 3.0
+    for _ in range(200):
+        k = (lo + hi) / 2
+        s = np.sum(p ** k)
+        if abs(s - 1.0) < tol:
+            break
+        if s > 1.0:
+            lo = k
+        else:
+            hi = k
+    q = p ** k
+    return q / q.sum()
+
+
+def devig_multiplicative(odds) -> np.ndarray:
+    p = implied(odds)
+    return p / p.sum()
+
+
+def blend(model_p: np.ndarray, market_p: np.ndarray, w: float) -> np.ndarray:
+    """Shrink the model toward the de-vigged market.
+
+    w=0 trusts the model completely, w=1 just copies the market. Somewhere
+    around 0.3-0.5 usually calibrates best on 1X2 in the top five leagues,
+    because those markets are very efficient. Use w=0 for corners and cards.
+    """
+    p = (1 - w) * np.asarray(model_p, float) + w * np.asarray(market_p, float)
+    return p / p.sum()
+
+
+def expected_value(p: float, odds: float) -> float:
+    """Profit per unit staked. 0.04 means a 4% edge."""
+    return p * odds - 1.0
+
+
+def kelly(p: float, odds: float, fraction: float = 0.25,
+          cap: float = 0.02) -> float:
+    """Fractional Kelly stake as a share of bankroll, hard-capped.
+
+    Full Kelly is mathematically optimal only if your probabilities are exactly
+    right. They are not, so quarter-Kelly with a 2% cap is the sane default.
+    """
+    b = odds - 1.0
+    if b <= 0:
+        return 0.0
+    f = (p * b - (1 - p)) / b
+    return float(min(max(f, 0.0) * fraction, cap))
+
+
+def find_value(probs: dict[str, float],
+               odds: dict[str, float],
+               min_edge: float = 0.04,
+               min_odds: float = 1.30,
+               max_odds: float = 8.0,
+               fraction: float = 0.25) -> list[dict]:
+    """Every selection whose expected value clears the threshold.
+
+    min_edge exists because your probabilities carry error. Betting at a 1%
+    modelled edge is betting on your own noise.
+    """
+    bets = []
+    for key, o in odds.items():
+        if o is None or not np.isfinite(o) or not (min_odds <= o <= max_odds):
+            continue
+        p = probs.get(key)
+        if p is None:
+            continue
+        ev = expected_value(p, o)
+        if ev >= min_edge:
+            bets.append({
+                "selection": key,
+                "model_prob": round(p, 4),
+                "odds": float(o),
+                "fair_odds": round(1 / p, 2) if p > 0 else None,
+                "edge": round(ev, 4),
+                "stake_pct": round(kelly(p, o, fraction) * 100, 2),
+            })
+    return sorted(bets, key=lambda b: -b["edge"])

--- a/footy/brief.py
+++ b/footy/brief.py
@@ -1,0 +1,230 @@
+"""One fixture, read in the right order.
+
+The order matters. Season-long numbers first, because they have the sample size.
+Then the venue-specific recent window, because that is the current squad and
+current tactics. Then the referee, because on cards he is worth more than either
+team. Then the model price, because it is the only number you can actually bet.
+
+Reading them the other way round — starting from the model price and looking for
+numbers that agree with it — is how you talk yourself into bad bets.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from . import analysis as A
+from .predict import predict_match
+
+METRICS = ["cards", "corners", "goals"]
+
+
+def _rank(table: pd.DataFrame, team: str, col: str) -> str:
+    if table.empty or team not in table.index or col not in table.columns:
+        return ""
+    r = int(table[col].rank(ascending=False, method="min").loc[team])
+    return f" ({r} of {len(table)})"
+
+
+def match_brief(df: pd.DataFrame, lm, home: str, away: str,
+                referee: str | None = None, n: int = 6,
+                season: str | None = None) -> dict:
+    """Every layer for one fixture, assembled but not yet interpreted."""
+    d = df[df["Div"] == lm.div]
+    season_tabs = {}
+    for metric in METRICS:
+        try:
+            season_tabs[metric] = A.season_table(d, metric, season=season)
+        except ValueError:
+            pass
+
+    adjusted = None
+    if lm.cards is not None:
+        try:
+            adjusted = A.discipline_table(d, lm.cards, season=season)
+        except ValueError:
+            pass
+
+    ref_row = None
+    if referee:
+        rt = A.referee_table(d, lm.cards, min_matches=1)
+        if referee in rt.index:
+            ref_row = rt.loc[referee].to_dict()
+            ref_row["referee"] = referee
+
+    teams = {}
+    for team, venue in ((home, "home"), (away, "away")):
+        entry = {"venue": venue, "season": {}, "recent": {}}
+        for metric, tab in season_tabs.items():
+            if team in tab.index:
+                row = tab.loc[team]
+                entry["season"][metric] = {
+                    "per_match": float(row["per_match"]),
+                    "home_per_match": float(row.get("home_per_match", np.nan)),
+                    "away_per_match": float(row.get("away_per_match", np.nan)),
+                    "rank": _rank(tab, team, "per_match"),
+                }
+            try:
+                entry["recent"][metric] = A.recent_form(
+                    d, team, metric, n=n, venue=venue)
+            except ValueError:
+                pass
+        if adjusted is not None and team in adjusted.index:
+            entry["card_index"] = adjusted.loc[team].to_dict()
+        entry["rest_days"] = _last_rest(d, team)
+        teams[team] = entry
+
+    return {
+        "fixture": f"{home} v {away}",
+        "div": lm.div,
+        "referee": ref_row,
+        "model": predict_match(lm, home, away, referee=referee, blend_1x2=0.0),
+        "teams": teams,
+        "h2h": A.head_to_head(d, home, away, n=6),
+        "n": n,
+    }
+
+
+def _last_rest(df: pd.DataFrame, team: str) -> float | None:
+    r = A.rest_days(df)
+    r = r[r["team"] == team].dropna(subset=["rest"])
+    return float(r["rest"].iloc[-1]) if len(r) else None
+
+
+def format_brief(b: dict) -> str:
+    """The brief as markdown, written to be read top to bottom."""
+    m, out = b["model"], [f"## {b['fixture']}"]
+    p = m["probs"]
+    out.append(
+        f"**Model line** — goals {m['xg_home']}–{m['xg_away']} · "
+        f"corners {m.get('exp_corners', '–')} · cards {m.get('exp_cards', '–')}"
+    )
+    out.append(
+        f"Home {p['home']*100:.0f}% · Draw {p['draw']*100:.0f}% · "
+        f"Away {p['away']*100:.0f}% · Over 2.5 {p['over_2.5']*100:.0f}% · "
+        f"BTTS {p['btts_yes']*100:.0f}%")
+    if "corners_over_9.5" in p:
+        out.append(f"Over 9.5 corners {p['corners_over_9.5']*100:.0f}% · "
+                   f"Over 3.5 cards {p.get('cards_over_3.5', 0)*100:.0f}% · "
+                   f"Over 35.5 booking points "
+                   f"{p.get('points_over_35.5', 0)*100:.0f}%")
+    out.append("")
+
+    # Referee
+    if b["referee"]:
+        r = b["referee"]
+        conf = ("thin sample — treat as a hint"
+                if r["matches"] < 15 else
+                "reasonable sample" if r["matches"] < 40 else "solid sample")
+        out.append(f"### Referee: {r['referee']}")
+        line = (f"{r['cards_per_match']:.2f} cards a match over {int(r['matches'])} "
+                f"games ({conf}), {r['points_per_match']:.0f} booking points, "
+                f"{r['reds_per_match']:.2f} reds.")
+        if "fouls_per_card" in r and np.isfinite(r.get("fouls_per_card", np.nan)):
+            line += f" A booking every {r['fouls_per_card']:.1f} fouls."
+        out.append(line)
+        out.append(f"Away sides get {r['home_bias']:+.2f} more cards than home "
+                   f"sides under him.")
+        if "factor" in r and np.isfinite(r.get("factor", np.nan)):
+            out.append(f"The model applies a **{r['factor']:.2f}×** adjustment "
+                       f"for him, already included in the line above.")
+        out.append("")
+    else:
+        out.append("### Referee: not set")
+        out.append("On cards markets the official is worth more than either "
+                   "team. Appointments are usually published two or three days "
+                   "before kickoff — find it before you bet a cards line.\n")
+
+    # Teams
+    for team, t in b["teams"].items():
+        out.append(f"### {team} — {t['venue']}")
+        for metric in METRICS:
+            s = t["season"].get(metric)
+            rec = t["recent"].get(metric)
+            if not s:
+                continue
+            venue_key = f"{t['venue']}_per_match"
+            bits = [f"season {s['per_match']:.2f}{s['rank']}",
+                    f"{t['venue']} {s[venue_key]:.2f}"]
+            if rec and rec.get("recent_avg") is not None:
+                bits.append(
+                    f"last {rec['matches']} {t['venue']} {rec['recent_avg']:.2f}"
+                    f" → shrunk **{rec['shrunk']:.2f}**")
+            out.append(f"- **{metric.capitalize()}**: " + " · ".join(bits))
+
+        ci = t.get("card_index")
+        if ci:
+            verdict = ("genuinely above expectation"
+                       if ci["signal"] == "real" and ci["ratio"] > 1 else
+                       "genuinely below expectation"
+                       if ci["signal"] == "real" else
+                       "within normal variation — do not bet on it")
+            out.append(f"- **Cards vs expectation**: {ci['ratio']:.2f}× "
+                       f"(±{ci['se']:.2f}), {verdict}")
+        if t["rest_days"] is not None:
+            note = " — short turnaround" if t["rest_days"] < 4 else ""
+            out.append(f"- **Rest**: {t['rest_days']:.0f} days{note}")
+        out.append("")
+
+    # Head to head
+    h2h = b["h2h"]
+    if len(h2h):
+        out.append("### Recent meetings")
+        for _, r in h2h.iterrows():
+            extra = []
+            if "HC" in r and pd.notna(r.get("HC")):
+                extra.append(f"{int(r['HC'] + r['AC'])} corners")
+            if "HY" in r and pd.notna(r.get("HY")):
+                cards = int(r["HY"] + r["AY"] + r.get("HR", 0) + r.get("AR", 0))
+                extra.append(f"{cards} cards")
+            out.append(
+                f"- {r['Date'].date()} {r['HomeTeam']} {int(r['FTHG'])}–"
+                f"{int(r['FTAG'])} {r['AwayTeam']}"
+                + (f" · {', '.join(extra)}" if extra else "")
+                + (f" · {r['Referee']}" if pd.notna(r.get("Referee")) else ""))
+        out.append("\nSquads turn over. Treat this as colour, not evidence.")
+
+    return "\n".join(out)
+
+
+def slate_scan(df: pd.DataFrame, models: dict, fixtures: pd.DataFrame,
+               metric: str = "cards", n: int = 6) -> pd.DataFrame:
+    """Rank a whole matchday by one metric, to find where to look first.
+
+    Sorting the slate by expected cards or corners and reading the top and
+    bottom five is a faster way to find a mispriced game than opening twenty
+    briefs in order.
+    """
+    rows = []
+    for _, f in fixtures.iterrows():
+        lm = models.get(f["Div"])
+        if lm is None:
+            continue
+        pred = predict_match(lm, f["HomeTeam"], f["AwayTeam"],
+                             referee=f.get("Referee"), blend_1x2=0.0)
+        d = df[df["Div"] == f["Div"]]
+        rec = {}
+        for team, venue in ((f["HomeTeam"], "home"), (f["AwayTeam"], "away")):
+            try:
+                rec[venue] = A.recent_form(d, team, metric, n=n,
+                                           venue=venue)["shrunk"]
+            except (ValueError, KeyError, TypeError):
+                rec[venue] = None
+        rows.append({
+            "Div": f["Div"],
+            "fixture": f'{f["HomeTeam"]} v {f["AwayTeam"]}',
+            "exp_goals": pred["xg_home"] + pred["xg_away"],
+            "exp_corners": pred.get("exp_corners"),
+            "exp_cards": pred.get("exp_cards"),
+            "referee": f.get("Referee"),
+            f"home_recent_{metric}": rec["home"],
+            f"away_recent_{metric}": rec["away"],
+            "over_2.5": pred["probs"]["over_2.5"],
+            "over_9.5_corners": pred["probs"].get("corners_over_9.5"),
+            "over_3.5_cards": pred["probs"].get("cards_over_3.5"),
+        })
+    out = pd.DataFrame(rows)
+    sort_col = {"cards": "exp_cards", "corners": "exp_corners",
+                "goals": "exp_goals"}.get(metric, "exp_cards")
+    return out.sort_values(sort_col, ascending=False).reset_index(drop=True)

--- a/footy/context.py
+++ b/footy/context.py
@@ -1,0 +1,93 @@
+"""The context layer - where corners and cards learn from the goals model.
+
+The idea worth stealing here: cards and corners are not independent of the match
+result. They are consequences of match *shape*.
+
+- A big mismatch means the favourite camps in the opposition half. Corners go
+  up, and they go up almost entirely on one side.
+- A big mismatch also means a less contested game. Fewer tactical fouls, fewer
+  flashpoints, fewer cards.
+- A tight game between evenly matched sides is where bookings live.
+
+So instead of modelling corners and cards in isolation, this fits a small
+correction on top of them using two quantities the goals model already gives
+you for free: expected supremacy (how one-sided) and expected total goals (how
+open). Two coefficients each, fitted by least squares on the residuals.
+
+Fit it, print the coefficients, and check they have the sign the theory
+predicts. If they do not, the effect is not there in your league and you should
+leave the adjustment off rather than fit noise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class ContextModel:
+    metric: str
+    total_coef: np.ndarray      # [const, |supremacy|, total goals]
+    share_coef: np.ndarray      # [const, supremacy]
+    r2_total: float
+    n: int
+
+    def describe(self) -> str:
+        c = self.total_coef
+        return (f"{self.metric}: total responds {c[1]:+.3f} per goal of "
+                f"supremacy and {c[2]:+.3f} per goal of expected total "
+                f"(R²={self.r2_total:.3f}, n={self.n}); share tilts "
+                f"{self.share_coef[1]:+.3f} per goal of supremacy")
+
+    def apply(self, lh: float, la: float, supremacy: float,
+              total_goals: float) -> tuple[float, float]:
+        """Rescale a count model's output for the shape of this match."""
+        x = np.array([1.0, abs(supremacy), total_goals])
+        mult = float(np.exp(np.clip(self.total_coef @ x, -0.5, 0.5)))
+        total = (lh + la) * mult
+
+        tilt = float(np.clip(self.share_coef @ np.array([1.0, supremacy]),
+                             -0.8, 0.8))
+        ratio = (lh / max(la, 1e-6)) * np.exp(tilt)
+        share_h = ratio / (1 + ratio)
+        return total * share_h, total * (1 - share_h)
+
+
+def fit_context(df: pd.DataFrame, goals_model, count_model,
+                home_col: str, away_col: str, metric: str) -> ContextModel:
+    """Regress the count model's error on match shape."""
+    d = df.dropna(subset=[home_col, away_col, "HomeTeam", "AwayTeam"])
+    if len(d) < 200:
+        raise ValueError(f"Need at least 200 matches to fit context, got {len(d)}.")
+
+    sup, tot, ratio_obs, ratio_exp, share_obs, share_exp = [], [], [], [], [], []
+    for _, r in d.iterrows():
+        gh, ga = goals_model.expected(r["HomeTeam"], r["AwayTeam"])
+        ch, ca = count_model.expected(r["HomeTeam"], r["AwayTeam"])
+        act_h, act_a = float(r[home_col]), float(r[away_col])
+        if ch + ca <= 0:
+            continue
+        sup.append(gh - ga)
+        tot.append(gh + ga)
+        ratio_obs.append(act_h + act_a)
+        ratio_exp.append(ch + ca)
+        share_obs.append(np.log((act_h + 0.5) / (act_a + 0.5)))
+        share_exp.append(np.log((ch + 0.5) / (ca + 0.5)))
+
+    sup = np.array(sup); tot = np.array(tot)
+    y_total = np.log(np.clip(np.array(ratio_obs), 0.5, None)
+                     / np.array(ratio_exp))
+    X_total = np.column_stack([np.ones_like(sup), np.abs(sup), tot])
+    beta, *_ = np.linalg.lstsq(X_total, y_total, rcond=None)
+    resid = y_total - X_total @ beta
+    r2 = 1 - resid.var() / y_total.var() if y_total.var() > 0 else 0.0
+
+    y_share = np.array(share_obs) - np.array(share_exp)
+    X_share = np.column_stack([np.ones_like(sup), sup])
+    gamma, *_ = np.linalg.lstsq(X_share, y_share, rcond=None)
+
+    return ContextModel(metric=metric, total_coef=beta, share_coef=gamma,
+                        r2_total=float(r2), n=len(sup))

--- a/footy/data.py
+++ b/footy/data.py
@@ -1,0 +1,199 @@
+"""Load historical match data and upcoming fixtures from football-data.co.uk.
+
+That source is free, needs no API key, and already carries everything the four
+target markets need: goals, corners, cards, fouls, shots, referee, and closing
+bookmaker odds.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import pandas as pd
+
+BASE = "https://www.football-data.co.uk/mmz4281"
+FIXTURES_URL = "https://www.football-data.co.uk/fixtures.csv"
+
+# Top-5 European leagues, football-data division codes.
+LEAGUES = {
+    "E0": "Premier League",
+    "SP1": "La Liga",
+    "I1": "Serie A",
+    "D1": "Bundesliga",
+    "F1": "Ligue 1",
+}
+
+# Columns we keep. Not every season has every one.
+KEEP = [
+    "Div", "Date", "Time", "HomeTeam", "AwayTeam", "Referee",
+    "FTHG", "FTAG", "FTR", "HTHG", "HTAG",
+    "HS", "AS", "HST", "AST", "HF", "AF", "HC", "AC", "HY", "AY", "HR", "AR",
+]
+
+# Odds columns, in preference order (closing average first, then closing max,
+# then pre-match average, then Bet365). Older seasons use the Bb* names.
+ODDS_1X2 = [
+    ("AvgCH", "AvgCD", "AvgCA"),
+    ("MaxCH", "MaxCD", "MaxCA"),
+    ("AvgH", "AvgD", "AvgA"),
+    ("BbAvH", "BbAvD", "BbAvA"),
+    ("B365H", "B365D", "B365A"),
+]
+ODDS_OU25 = [
+    ("AvgC>2.5", "AvgC<2.5"),
+    ("Avg>2.5", "Avg<2.5"),
+    ("BbAv>2.5", "BbAv<2.5"),
+    ("B365>2.5", "B365<2.5"),
+]
+
+
+def _read_csv(source) -> pd.DataFrame:
+    """Read one football-data CSV whatever encoding it happens to use.
+
+    The archive is a mix: some season files are plain latin-1, others are UTF-8
+    with a byte-order mark, and which is which changes without warning. Reading
+    a BOM'd file as latin-1 turns the first header into 'ï»¿Div' rather than
+    'Div', so the division column silently disappears and every later
+    ``df[df["Div"] == div]`` filter drops that whole season on the floor. No
+    error is raised anywhere, so it shows up only as a model quietly fitted on
+    less data than you asked for.
+
+    Try UTF-8 first, fall back to latin-1, then strip any BOM left in a header
+    so caches written by an earlier version repair themselves on read.
+    """
+    try:
+        df = pd.read_csv(source, encoding="utf-8-sig")
+    except UnicodeDecodeError:
+        df = pd.read_csv(source, encoding="latin-1")
+    df.columns = [str(c).replace("\ufeff", "").replace("ï»¿", "").strip()
+                  for c in df.columns]
+    return df
+
+
+def current_season_start(today: pd.Timestamp | None = None) -> int:
+    """Calendar year the season now in progress began in.
+
+    European seasons run August to May, so in the first half of a calendar year
+    the current season is the one that started the previous August.
+    """
+    today = pd.Timestamp.today() if today is None else today
+    return int(today.year if today.month >= 7 else today.year - 1)
+
+
+def season_codes(start_year: int, n_seasons: int) -> list[str]:
+    """2021 -> '2122'. Returns n_seasons codes ending at the most recent."""
+    out = []
+    for y in range(start_year, start_year + n_seasons):
+        out.append(f"{y % 100:02d}{(y + 1) % 100:02d}")
+    return out
+
+
+def _first_available(df: pd.DataFrame, groups: Iterable[tuple]) -> tuple | None:
+    for cols in groups:
+        if all(c in df.columns for c in cols):
+            sub = df[list(cols)]
+            if sub.notna().any().any():
+                return cols
+    return None
+
+
+def load_season(div: str, season: str, cache_dir: str = "cache") -> pd.DataFrame:
+    """Download (and cache) one division-season."""
+    os.makedirs(cache_dir, exist_ok=True)
+    path = os.path.join(cache_dir, f"{div}_{season}.csv")
+    if os.path.exists(path):
+        raw = _read_csv(path)
+    else:
+        url = f"{BASE}/{season}/{div}.csv"
+        raw = _read_csv(url)
+        raw.to_csv(path, index=False)
+
+    df = raw.copy()
+    df["season"] = season
+
+    cols = [c for c in KEEP if c in df.columns]
+    odds_cols = []
+
+    g = _first_available(df, ODDS_1X2)
+    if g:
+        df[["odds_h", "odds_d", "odds_a"]] = df[list(g)]
+        odds_cols += ["odds_h", "odds_d", "odds_a"]
+
+    g = _first_available(df, ODDS_OU25)
+    if g:
+        df[["odds_o25", "odds_u25"]] = df[list(g)]
+        odds_cols += ["odds_o25", "odds_u25"]
+
+    df = df[cols + odds_cols + ["season"]]
+    df["Date"] = pd.to_datetime(df["Date"], dayfirst=True, errors="coerce")
+    df = df.dropna(subset=["Date", "HomeTeam", "AwayTeam", "FTHG", "FTAG"])
+
+    for c in ["FTHG", "FTAG", "HC", "AC", "HY", "AY", "HR", "AR", "HS", "AS",
+              "HST", "AST", "HF", "AF"]:
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    return df.reset_index(drop=True)
+
+
+def load_history(divs: Iterable[str] = tuple(LEAGUES),
+                 start_year: int | None = None,
+                 n_seasons: int = 7,
+                 cache_dir: str = "cache") -> pd.DataFrame:
+    """Everything we can get, for the given divisions.
+
+    start_year defaults to whatever ends the run at the season now in progress,
+    so the window follows the calendar instead of drifting out of date.
+    """
+    if start_year is None:
+        start_year = current_season_start() - n_seasons + 1
+    frames = []
+    for div in divs:
+        for season in season_codes(start_year, n_seasons):
+            try:
+                frames.append(load_season(div, season, cache_dir))
+            except Exception as exc:  # season not published yet, or 404
+                print(f"  skip {div} {season}: {type(exc).__name__}")
+    if not frames:
+        raise RuntimeError("No data downloaded. Check your internet connection.")
+    df = pd.concat(frames, ignore_index=True).sort_values("Date")
+    return add_derived(df).reset_index(drop=True)
+
+
+def add_derived(df: pd.DataFrame) -> pd.DataFrame:
+    """Totals the market models are fitted on."""
+    df = df.copy()
+    if "HC" in df.columns:
+        df["corners_total"] = df["HC"] + df["AC"]
+    # Bookings points: 10 per yellow, 25 per red (standard market convention).
+    if "HY" in df.columns:
+        df["home_cards"] = df["HY"].fillna(0) + df["HR"].fillna(0)
+        df["away_cards"] = df["AY"].fillna(0) + df["AR"].fillna(0)
+        df["cards_total"] = df["home_cards"] + df["away_cards"]
+        df["booking_points"] = (
+            10 * (df["HY"].fillna(0) + df["AY"].fillna(0))
+            + 25 * (df["HR"].fillna(0) + df["AR"].fillna(0))
+        )
+    return df
+
+
+def load_fixtures(divs: Iterable[str] = tuple(LEAGUES)) -> pd.DataFrame:
+    """Upcoming matches for the next ~7 days, with current 1X2 and O/U odds."""
+    df = _read_csv(FIXTURES_URL)
+    df = df[df["Div"].isin(list(divs))].copy()
+    df["Date"] = pd.to_datetime(df["Date"], dayfirst=True, errors="coerce")
+
+    g = _first_available(df, ODDS_1X2)
+    if g:
+        df[["odds_h", "odds_d", "odds_a"]] = df[list(g)]
+    g = _first_available(df, ODDS_OU25)
+    if g:
+        df[["odds_o25", "odds_u25"]] = df[list(g)]
+
+    # Referee matters here: appointments are published a few days out and the
+    # card model applies a per-official multiplier once it knows who it is.
+    keep = [c for c in ["Div", "Date", "Time", "HomeTeam", "AwayTeam", "Referee",
+                        "odds_h", "odds_d", "odds_a", "odds_o25", "odds_u25"]
+            if c in df.columns]
+    return df[keep].dropna(subset=["HomeTeam", "AwayTeam"]).reset_index(drop=True)

--- a/footy/markets.py
+++ b/footy/markets.py
@@ -1,0 +1,75 @@
+"""Turn a joint count distribution into probabilities for each market.
+
+The same three helpers cover goals, corners and cards - a corners over 10.5 bet
+is arithmetically the same object as an over 2.5 goals bet, just with a
+different matrix underneath.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+DEFAULT_GOAL_LINES = [1.5, 2.5, 3.5, 4.5]
+DEFAULT_CORNER_LINES = [8.5, 9.5, 10.5, 11.5, 12.5]
+DEFAULT_CARD_LINES = [2.5, 3.5, 4.5, 5.5, 6.5]
+
+
+def outcome_probs(m: np.ndarray) -> dict[str, float]:
+    """Home win / draw / away win from a score matrix."""
+    home = float(np.tril(m, -1).sum())
+    draw = float(np.trace(m))
+    away = float(np.triu(m, 1).sum())
+    return {"home": home, "draw": draw, "away": away}
+
+
+def over_under(m: np.ndarray, lines) -> dict[str, float]:
+    """P(total > line) for each line. Lines must be half-integers."""
+    n = m.shape[0]
+    tot = np.add.outer(np.arange(n), np.arange(n))
+    out = {}
+    for ln in lines:
+        p_over = float(m[tot > ln].sum())
+        out[f"over_{ln}"] = p_over
+        out[f"under_{ln}"] = 1.0 - p_over
+    return out
+
+
+def btts(m: np.ndarray) -> dict[str, float]:
+    """Both teams to score."""
+    p_yes = float(m[1:, 1:].sum())
+    return {"btts_yes": p_yes, "btts_no": 1.0 - p_yes}
+
+
+def correct_scores(m: np.ndarray, top: int = 6) -> list[tuple[str, float]]:
+    idx = np.dstack(np.unravel_index(np.argsort(m, axis=None)[::-1], m.shape))[0]
+    return [(f"{i}-{j}", float(m[i, j])) for i, j in idx[:top]]
+
+
+def handicap_line(m: np.ndarray) -> dict[str, float]:
+    """Most corners / most cards style markets, plus the tie."""
+    return {
+        "home_more": float(np.tril(m, -1).sum()),
+        "equal": float(np.trace(m)),
+        "away_more": float(np.triu(m, 1).sum()),
+    }
+
+
+def booking_points_over(lh: float, la: float, line: float,
+                        p_red: float = 0.055, max_cards: int = 12) -> float:
+    """P(booking points > line), 10 per yellow and 25 per red.
+
+    Reds are treated as a thinned fraction of each side's card rate, which is
+    close enough given how rare they are (roughly 5-6% of all cards).
+    """
+    from scipy.stats import poisson
+
+    lam_y = (lh + la) * (1 - p_red)
+    lam_r = (lh + la) * p_red
+    ys = np.arange(max_cards + 1)
+    rs = np.arange(5)
+    py = poisson.pmf(ys, lam_y)
+    pr = poisson.pmf(rs, lam_r)
+    pts = np.add.outer(10 * ys, 25 * rs)
+    joint = np.outer(py, pr)
+    joint = joint / joint.sum()
+    return float(joint[pts > line].sum())

--- a/footy/predict.py
+++ b/footy/predict.py
@@ -1,0 +1,133 @@
+"""Fit goals, corners and cards models per league, then predict a fixture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from . import markets as mk
+from .betting import blend, devig_power
+from .context import ContextModel, fit_context
+from .ratings import RatingModel, fit_ratings, score_matrix
+
+# Corners and cards drift more slowly than form, so they remember longer.
+HALF_LIVES = {"goals": 270.0, "corners": 400.0, "cards": 500.0}
+
+
+@dataclass
+class LeagueModels:
+    div: str
+    goals: RatingModel
+    corners: RatingModel | None
+    cards: RatingModel | None
+    trained_to: pd.Timestamp
+    n_matches: int
+    ctx_corners: ContextModel | None = None
+    ctx_cards: ContextModel | None = None
+
+
+def fit_league(df: pd.DataFrame, div: str,
+               as_of: pd.Timestamp | None = None,
+               with_context: bool = True) -> LeagueModels:
+    d = df[df["Div"] == div]
+
+    goals = fit_ratings(d, "FTHG", "FTAG", as_of=as_of,
+                        half_life_days=HALF_LIVES["goals"], use_dc=True)
+
+    corners = None
+    if "HC" in d.columns and d["HC"].notna().sum() > 100:
+        corners = fit_ratings(d, "HC", "AC", as_of=as_of,
+                              half_life_days=HALF_LIVES["corners"])
+
+    cards = None
+    if "home_cards" in d.columns and d["home_cards"].notna().sum() > 100:
+        cards = fit_ratings(d, "home_cards", "away_cards", as_of=as_of,
+                            half_life_days=HALF_LIVES["cards"],
+                            ref_col="Referee")
+
+    used = d if as_of is None else d[d["Date"] < as_of]
+    lm = LeagueModels(div=div, goals=goals, corners=corners, cards=cards,
+                      trained_to=as_of or d["Date"].max(), n_matches=len(used))
+
+    if with_context:
+        for attr, cols, cm, name in [
+                ("ctx_corners", ("HC", "AC"), corners, "corners"),
+                ("ctx_cards", ("home_cards", "away_cards"), cards, "cards")]:
+            if cm is None:
+                continue
+            try:
+                setattr(lm, attr, fit_context(used, goals, cm, *cols, name))
+            except Exception:
+                pass
+    return lm
+
+
+def predict_match(lm: LeagueModels, home: str, away: str,
+                  referee: str | None = None,
+                  market_odds: dict | None = None,
+                  blend_1x2: float = 0.35) -> dict:
+    """All market probabilities for one fixture.
+
+    market_odds may contain odds_h/odds_d/odds_a and odds_o25/odds_u25. When
+    1X2 odds are present the model is blended toward the de-vigged market,
+    which improves calibration a lot on these five leagues.
+    """
+    lh, la = lm.goals.expected(home, away)
+    m = score_matrix(lh, la, rho=lm.goals.rho, use_dc=True)
+
+    probs: dict[str, float] = {}
+    o = mk.outcome_probs(m)
+
+    if market_odds and all(market_odds.get(k) for k in ("odds_h", "odds_d", "odds_a")):
+        fair = devig_power([market_odds["odds_h"], market_odds["odds_d"],
+                            market_odds["odds_a"]])
+        vec = blend([o["home"], o["draw"], o["away"]], fair, blend_1x2)
+        o = {"home": vec[0], "draw": vec[1], "away": vec[2]}
+
+    probs.update(o)
+    probs["home_or_draw"] = o["home"] + o["draw"]
+    probs["away_or_draw"] = o["away"] + o["draw"]
+    probs["home_or_away"] = o["home"] + o["away"]
+    probs.update(mk.over_under(m, mk.DEFAULT_GOAL_LINES))
+    probs.update(mk.btts(m))
+
+    out = {
+        "home": home, "away": away, "div": lm.div, "referee": referee,
+        "xg_home": round(lh, 2), "xg_away": round(la, 2),
+        "top_scores": mk.correct_scores(m),
+        "probs": probs,
+    }
+
+    if lm.corners:
+        ch, ca = lm.corners.expected(home, away)
+        if lm.ctx_corners:
+            ch, ca = lm.ctx_corners.apply(ch, ca, lh - la, lh + la)
+        cm = score_matrix(ch, ca, max_goals=25)
+        cprobs = {f"corners_{k}": v
+                  for k, v in mk.over_under(cm, mk.DEFAULT_CORNER_LINES).items()}
+        hcap = mk.handicap_line(cm)
+        cprobs["corners_home_more"] = hcap["home_more"]
+        cprobs["corners_away_more"] = hcap["away_more"]
+        probs.update(cprobs)
+        out["exp_corners"] = round(ch + ca, 2)
+
+    if lm.cards:
+        kh, ka = lm.cards.expected(home, away, referee=referee)
+        if lm.ctx_cards:
+            kh, ka = lm.ctx_cards.apply(kh, ka, lh - la, lh + la)
+        km = score_matrix(kh, ka, max_goals=12)
+        kprobs = {f"cards_{k}": v
+                  for k, v in mk.over_under(km, mk.DEFAULT_CARD_LINES).items()}
+        for line in (25.5, 35.5, 45.5, 55.5):
+            p = mk.booking_points_over(kh, ka, line)
+            kprobs[f"points_over_{line}"] = p
+            kprobs[f"points_under_{line}"] = 1 - p
+        probs.update(kprobs)
+        out["exp_cards"] = round(kh + ka, 2)
+        out["ref_factor"] = round(lm.cards.ref_factor.get(referee, 1.0), 2) \
+            if referee else None
+
+    out["probs"] = {k: round(float(v), 4) for k, v in probs.items()}
+    return out

--- a/footy/ratings.py
+++ b/footy/ratings.py
@@ -1,0 +1,189 @@
+"""Rating engines.
+
+One idea, used three times. Every match outcome we care about (goals, corners,
+cards) is a pair of counts, one per side. We model each side's expected count as
+
+    log(lambda_home) = base + attack_home + defence_away + home_edge
+    log(lambda_away) = base + attack_away + defence_home
+
+fitted by maximum likelihood with exponential time decay, so last month counts
+for more than three years ago.
+
+For goals we add the Dixon-Coles low-score correction, which fixes the fact that
+plain Poisson underestimates 0-0 and 1-1 and so misprices draws.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+from scipy.stats import poisson
+
+
+def _tau(h, a, lh, la, rho):
+    """Dixon-Coles dependence correction on the four lowest scorelines."""
+    t = np.ones(len(h))
+    m = (h == 0) & (a == 0); t[m] = 1.0 - lh[m] * la[m] * rho
+    m = (h == 0) & (a == 1); t[m] = 1.0 + lh[m] * rho
+    m = (h == 1) & (a == 0); t[m] = 1.0 + la[m] * rho
+    m = (h == 1) & (a == 1); t[m] = 1.0 - rho
+    return np.clip(t, 1e-9, None)
+
+
+@dataclass
+class RatingModel:
+    """Fitted attack/defence ratings for one count type in one league."""
+
+    teams: list[str]
+    attack: np.ndarray
+    defence: np.ndarray
+    home_edge: float
+    base: float
+    rho: float = 0.0
+    use_dc: bool = False
+    ref_factor: dict[str, float] = field(default_factory=dict)
+
+    def _idx(self, team: str) -> int | None:
+        try:
+            return self.teams.index(team)
+        except ValueError:
+            return None
+
+    def expected(self, home: str, away: str, referee: str | None = None
+                 ) -> tuple[float, float]:
+        """Expected count for each side. Unknown teams fall back to average."""
+        i, j = self._idx(home), self._idx(away)
+        ah = self.attack[i] if i is not None else 0.0
+        dh = self.defence[i] if i is not None else 0.0
+        aa = self.attack[j] if j is not None else 0.0
+        da = self.defence[j] if j is not None else 0.0
+
+        lh = np.exp(self.base + ah + da + self.home_edge)
+        la = np.exp(self.base + aa + dh)
+
+        if referee and self.ref_factor:
+            f = self.ref_factor.get(referee, 1.0)
+            lh, la = lh * f, la * f
+        return float(lh), float(la)
+
+
+def fit_ratings(df: pd.DataFrame,
+                home_col: str,
+                away_col: str,
+                *,
+                as_of: pd.Timestamp | None = None,
+                half_life_days: float = 270.0,
+                use_dc: bool = False,
+                l2: float = 0.02,
+                ref_col: str | None = None) -> RatingModel:
+    """Fit one rating model to matches strictly before `as_of`.
+
+    half_life_days controls memory. 270 is a reasonable default for goals;
+    corners and cards are more stable, so they tolerate a longer half-life.
+    """
+    d = df.dropna(subset=[home_col, away_col, "HomeTeam", "AwayTeam", "Date"])
+    if as_of is not None:
+        d = d[d["Date"] < as_of]
+    if len(d) < 60:
+        raise ValueError(f"Only {len(d)} matches available - need at least 60.")
+
+    teams = sorted(set(d["HomeTeam"]) | set(d["AwayTeam"]))
+    tix = {t: i for i, t in enumerate(teams)}
+    n = len(teams)
+
+    hi = d["HomeTeam"].map(tix).to_numpy()
+    ai = d["AwayTeam"].map(tix).to_numpy()
+    hg = d[home_col].to_numpy(dtype=float)
+    ag = d[away_col].to_numpy(dtype=float)
+
+    ref_date = as_of if as_of is not None else d["Date"].max()
+    age = (ref_date - d["Date"]).dt.days.to_numpy(dtype=float)
+    xi = np.log(2) / half_life_days
+    w = np.exp(-xi * np.clip(age, 0, None))
+
+    base0 = np.log(max(np.average(np.r_[hg, ag], weights=np.r_[w, w]), 0.05))
+
+    def unpack(p):
+        atk = np.r_[p[:n - 1], -p[:n - 1].sum()]   # sum-to-zero identifiability
+        dfn = np.r_[p[n - 1:2 * n - 2], -p[n - 1:2 * n - 2].sum()]
+        return atk, dfn, p[2 * n - 2], p[2 * n - 1], (p[2 * n] if use_dc else 0.0)
+
+    def nll(p):
+        atk, dfn, home_edge, base, rho = unpack(p)
+        lh = np.exp(base + atk[hi] + dfn[ai] + home_edge)
+        la = np.exp(base + atk[ai] + dfn[hi])
+        lh = np.clip(lh, 1e-6, 25.0)
+        la = np.clip(la, 1e-6, 25.0)
+
+        ll = poisson.logpmf(hg, lh) + poisson.logpmf(ag, la)
+        if use_dc:
+            ll = ll + np.log(_tau(hg, ag, lh, la, rho))
+        pen = l2 * (np.sum(atk ** 2) + np.sum(dfn ** 2))
+        return -np.sum(w * ll) + pen
+
+    x0 = np.zeros(2 * n)
+    x0[2 * n - 2] = 0.25          # home edge
+    x0[2 * n - 1] = base0
+    bounds = [(-3, 3)] * (2 * n - 2) + [(-1, 1), (-3, 3)]
+    if use_dc:
+        x0 = np.r_[x0, -0.05]
+        bounds = bounds + [(-0.25, 0.25)]
+
+    res = minimize(nll, x0, method="L-BFGS-B", bounds=bounds,
+                   options={"maxiter": 800})
+    atk, dfn, home_edge, base, rho = unpack(res.x)
+
+    model = RatingModel(teams=teams, attack=atk, defence=dfn,
+                        home_edge=float(home_edge), base=float(base),
+                        rho=float(rho), use_dc=use_dc)
+
+    if ref_col and ref_col in d.columns:
+        model.ref_factor = _referee_factors(d, model, home_col, away_col,
+                                            ref_col, w)
+    return model
+
+
+def _referee_factors(d, model, home_col, away_col, ref_col, w,
+                     prior_matches: float = 30.0) -> dict[str, float]:
+    """How many more (or fewer) cards a referee gives than the teams imply.
+
+    Shrunk toward 1.0 by match count, so a ref with 4 games barely moves.
+    """
+    tix = {t: i for i, t in enumerate(model.teams)}
+    hi = d["HomeTeam"].map(tix).to_numpy()
+    ai = d["AwayTeam"].map(tix).to_numpy()
+    ok = pd.notna(hi) & pd.notna(ai) & d[ref_col].notna().to_numpy()
+    if not ok.any():
+        return {}
+
+    hi, ai = hi[ok].astype(int), ai[ok].astype(int)
+    wv = np.asarray(w)[ok]
+    exp = (np.exp(model.base + model.attack[hi] + model.defence[ai]
+                  + model.home_edge)
+           + np.exp(model.base + model.attack[ai] + model.defence[hi]))
+    act = (d[home_col].to_numpy()[ok] + d[away_col].to_numpy()[ok])
+
+    g = pd.DataFrame({"ref": d[ref_col].to_numpy()[ok],
+                      "e": wv * exp, "a": wv * act, "w": wv}).groupby("ref").sum()
+    g = g[g["e"] > 0]
+    k = g["w"] / (g["w"] + prior_matches)
+    factor = np.clip(1.0 + k * (g["a"] / g["e"] - 1.0), 0.6, 1.6)
+    return {str(r): float(v) for r, v in factor.items()}
+
+
+def score_matrix(lh: float, la: float, max_goals: int = 15,
+                 rho: float = 0.0, use_dc: bool = False) -> np.ndarray:
+    """Joint distribution over (home count, away count)."""
+    h = poisson.pmf(np.arange(max_goals + 1), lh)
+    a = poisson.pmf(np.arange(max_goals + 1), la)
+    m = np.outer(h, a)
+    if use_dc and rho != 0.0:
+        m[0, 0] *= 1.0 - lh * la * rho
+        m[0, 1] *= 1.0 + lh * rho
+        m[1, 0] *= 1.0 + la * rho
+        m[1, 1] *= 1.0 - rho
+        m = np.clip(m, 0, None)
+    return m / m.sum()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas>=2.0
+numpy>=1.24
+scipy>=1.10
+streamlit>=1.32

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Launch Football Edge. Creates a virtualenv on first run, then starts the app.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PY="${PYTHON:-python3}"
+if ! "$PY" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+  echo "Need Python 3.10 or newer; found $("$PY" --version 2>&1)." >&2
+  echo "Set PYTHON=/path/to/python3.11 to point at a different interpreter." >&2
+  exit 1
+fi
+
+if [ ! -d .venv ]; then
+  echo "Creating virtualenv in .venv ..."
+  "$PY" -m venv .venv
+  ./.venv/bin/pip install --quiet --upgrade pip
+  ./.venv/bin/pip install --quiet -r requirements.txt
+fi
+
+echo "Starting Football Edge on http://localhost:8501"
+echo "First run downloads ~7 seasons per league and caches them in cache/;"
+echo "that takes a minute or two, after which startup is quick."
+exec ./.venv/bin/streamlit run app.py "$@"


### PR DESCRIPTION
Brings in the Streamlit app that prices top-five-league fixtures across
match result, goals, corners and cards, then compares those prices to the
bookmaker's. Running it against live football-data.co.uk turned up four
things that needed fixing before it worked as described.

CSV encoding. The archive mixes latin-1 files with UTF-8-with-BOM ones and
switches between them without warning, but the loader forced latin-1. On a
BOM'd file that turns the first header into 'ï»¿Div' instead of 'Div', so
the division column vanished and every df[df["Div"] == div] filter dropped
that season silently. Seven seasons of Premier League data came out as four
(1520 of 2670 rows), with no error anywhere. The affected seasons were the
most recent ones, including the current one. load_fixtures hit the same file
format and raised KeyError: 'Div', which the app caught and reported as
"fixture list unavailable" — the whole "This week" tab was dead. Reads now
try UTF-8 first and fall back to latin-1, and headers are stripped of any
BOM so caches written by the old path repair themselves on read.

Stale season window. The sidebar defaulted to 2019 and capped the first
season at 2025, so the run ended before the season now in progress and there
was no way to reach it. The window is now derived from the calendar and ends
at the current season.

Booking points in season_table. to_team_rows built points_for but not
points_against, so selecting "points" in the Scouting tab raised
KeyError: 'Column not found: points_against'.

Unused referee on upcoming fixtures. The fixture feed carries the appointed
official, but load_fixtures dropped the column, so the "This week" tab priced
every match with no referee and the card model's per-official multiplier —
which the README calls the biggest available edge in the cards market — never
applied. The column is kept and passed through, and shown on the fixture card.

Verified against live data: all five leagues load with no dropped rows, the
fixtures tab renders 48 upcoming matches, and all four tabs run clean in a
browser with no exceptions.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SiLTCSvYbXx4JUWePq69S